### PR TITLE
Various fixes

### DIFF
--- a/beer.php
+++ b/beer.php
@@ -4,11 +4,11 @@ require ("untappdPHP.php");
 
 // Function for Vowels
 function checkifvowel($string) {
-		
+
 	$v = strtolower($string[0]);
-	
+
 	$beer_name = explode(" ", $string);
-	
+
 	if (sizeof($beer_name) > 1 && strtolower($beer_name[0]) == "the")
 	{
 		return "";
@@ -40,8 +40,11 @@ if (isset($_POST)) {
 		$data["text"] = "Post is not empty, but has no results";
 
 	} else {
-		if (isset($event_json->text) && isset($event_json) && $event_json->trigger_word == "untappd") {
+		if (isset($event_json) && isset($event_json->text)) {
 			$beer_name = explode("untappd", $event_json->text);
+			if ( ! array_key_exists('1', $beer_name) ){
+				$beer_name = explode("Untappd", $event_json->text);
+			}
 
 			$real_beer_name = trim($beer_name[1]);
 


### PR DESCRIPTION
1. Changes the isset check order to bail early if the var isn't set before checking a key on it.
   Before, was checking for `$event_json->text` before `$event_json`. The latter would never fail if the first worked, so switching it so we can give up early if `$event_json` wasn't set.
   props to @dbspringer for pointing it out.
2. Removes the check for the trigger word. It is a single-word script.
   This also added the problem that Slack would trigger the integration with "Untappd" but the script wasn't doing anything with that.
3. If "Untappd [beer name]" is used, roll with it.
   Currently, `explode` is hitting `untappd` only. Now, check for the presence of a second item in the array. If it is absent, then `explode` didn't explode anything out, so let's try again.
